### PR TITLE
Remove duplicated dot in description

### DIFF
--- a/vscode/config.yaml
+++ b/vscode/config.yaml
@@ -2,7 +2,7 @@
 name: Studio Code Server
 version: dev
 slug: vscode
-description: Fully featured Visual Studio Code (VSCode) experience integrated in the Home Assistant frontend.
+description: Fully featured Visual Studio Code (VSCode) experience integrated in the Home Assistant frontend
 url: https://github.com/hassio-addons/addon-vscode
 ingress: true
 ingress_port: 1337


### PR DESCRIPTION
# Proposed Changes

Removes the duplicated dot from the add-on description.

<img width="948" height="327" alt="image" src="https://github.com/user-attachments/assets/65e4b70b-f8f9-40bf-83b9-099a0e654f57" />

## Related Issues

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting update to configuration settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->