### PR TITLE
Fix SSH key symlink creating nested .ssh directory

### DIFF
--- a/vscode/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
+++ b/vscode/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
@@ -31,6 +31,9 @@ if ! bashio::fs.directory_exists "${SSH_USER_PATH}"; then
         || bashio::exit.nok \
             'Failed setting permissions on persistent .ssh folder'
 fi
+if [ -d ~/.ssh ] && [ ! -L ~/.ssh ]; then
+    rm -rf ~/.ssh
+fi
 ln -sn "${SSH_USER_PATH}" ~/.ssh || bashio::log.warning "Failed linking .ssh"
 
 # Sets up ZSH shell

--- a/vscode/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
+++ b/vscode/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
@@ -31,10 +31,16 @@ if ! bashio::fs.directory_exists "${SSH_USER_PATH}"; then
         || bashio::exit.nok \
             'Failed setting permissions on persistent .ssh folder'
 fi
-if [ -d ~/.ssh ] && [ ! -L ~/.ssh ]; then
-    rm -rf ~/.ssh
+
+# The image ships an empty ~/.ssh; without removing it, the link below
+# would end up inside it as ~/.ssh/.ssh instead of replacing it.
+if [[ -d ~/.ssh ]] && [[ ! -L ~/.ssh ]]; then
+    # Clean up the nested link left behind by earlier versions
+    rm -f ~/.ssh/.ssh
+    rmdir ~/.ssh \
+        || bashio::log.warning "Not replacing non-empty ${HOME}/.ssh"
 fi
-ln -sn "${SSH_USER_PATH}" ~/.ssh || bashio::log.warning "Failed linking .ssh"
+ln -sfn "${SSH_USER_PATH}" ~/.ssh || bashio::log.warning "Failed linking .ssh"
 
 # Sets up ZSH shell
 touch "${ZSH_HISTORY_PERSISTANT_FILE}" \


### PR DESCRIPTION
Fixes #1066

When the init-user script runs, it creates a symlink from `~/.ssh` to `/data/.ssh` (the persistent storage location). However, if `~/.ssh` already exists as a real directory (not a symlink), the `ln -sn` command places the symlink *inside* that directory, resulting in `~/.ssh/.ssh -> /data/.ssh` instead of the intended `~/.ssh -> /data/.ssh`. The `-n` flag only prevents following an existing symlink at the target; it does not prevent ln from placing the new link inside an existing real directory.

This causes SSH authentication to fail because ssh looks for keys in `~/.ssh/` (the real directory) rather than in `/data/.ssh/` where the keys actually reside. Users had to manually run `ssh-add` or copy keys from `~/.ssh/.ssh/` back into `~/.ssh/` as a workaround.

The fix removes `~/.ssh` if it exists as a real directory (not a symlink) before creating the symlink. This ensures the symlink is always created correctly as `~/.ssh -> /data/.ssh` regardless of prior state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH initialization when an existing `~/.ssh` directory conflicts with the expected setup.
  * Prevented removal of non-empty SSH directories and cleaned up legacy nested links safely.
  * Improved reliability when creating the SSH link, reducing setup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->