### PR TITLE
⬆️ Update locales and zsh to current version

### DIFF
--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -33,7 +33,7 @@ RUN \
         colordiff=1.0.21-1 \
         git=1:2.47.3-0+deb13u1 \
         iputils-ping=3:20240905-3 \
-        locales=2.41-12 \
+        locales=2.41-12+deb13u1 \
         mariadb-client=1:11.8.3-0+deb13u1 \
         mosquitto-clients=2.0.21-1 \
         net-tools=2.10-1.3 \
@@ -47,7 +47,7 @@ RUN \
         uuid-runtime=2.41-5 \
         wget=1.25.0-2 \
         zip=3.0-15 \
-        zsh=5.9-8+b14 \
+        zsh=5.9-8+b18 \
         less=668-1 \
     \
     && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \


### PR DESCRIPTION
# Proposed Changes

I have updated the package version for locales and zsh to versions which are available, this should fix the build process

## Related Issues

all current PRs are failing because they can not be build

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base image dependencies in container configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->