### PR TITLE
Update code-server and base image dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,7 +34,7 @@
         "ARG CODE_SERVER_VERSION=[\"']?(?<currentValue>.+?)[\"']?\\s+"
       ],
       "datasourceTemplate": "github-releases",
-      "depNameTemplate": "cdr/code-server"
+      "depNameTemplate": "coder/code-server"
     },
     {
       "customType": "regex",

--- a/vscode/Dockerfile
+++ b/vscode/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:9.1.0
+ARG BUILD_FROM=ghcr.io/hassio-addons/debian-base:9.3.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -20,26 +20,26 @@ COPY vscode.extensions /root/vscode.extensions
 
 # Setup base system
 ARG BUILD_ARCH=amd64
-ARG CODE_SERVER_VERSION="v4.106.2"
-ARG HA_CLI_VERSION="4.42.0"
+ARG CODE_SERVER_VERSION="v4.130.0"
+ARG HA_CLI_VERSION="5.2.0"
 # hadolint ignore=SC2181, DL3008
 RUN \
     apt-get update \
     \
     && apt-get install -y --no-install-recommends \
         ack=3.8.1-1 \
-        libarchive-tools=3.7.4-4 \
+        libarchive-tools=3.7.4-4+deb13u1 \
         build-essential=12.12 \
         colordiff=1.0.21-1 \
         git=1:2.47.3-0+deb13u1 \
         iputils-ping=3:20240905-3 \
-        locales=2.41-12 \
-        mariadb-client=1:11.8.3-0+deb13u1 \
+        locales=2.41-12+deb13u3 \
+        mariadb-client=1:11.8.6-0+deb13u1 \
         mosquitto-clients=2.0.21-1 \
         net-tools=2.10-1.3 \
         nmap=7.95+dfsg-3 \
-        openssh-client=1:10.0p1-7 \
-        openssl=3.5.4-1~deb13u1 \
+        openssh-client=1:10.0p1-7+deb13u4 \
+        openssl=3.5.6-1~deb13u2 \
         python3-dev=3.13.5-1 \
         python3-venv=3.13.5-1 \
         python3=3.13.5-1 \
@@ -47,7 +47,7 @@ RUN \
         uuid-runtime=2.41-5 \
         wget=1.25.0-2 \
         zip=3.0-15 \
-        zsh=5.9-8+b14 \
+        zsh=5.9-8+b23 \
         less=668-1 \
     \
     && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \

--- a/vscode/build.yaml
+++ b/vscode/build.yaml
@@ -1,4 +1,4 @@
 ---
 build_from:
-  aarch64: ghcr.io/hassio-addons/debian-base:9.1.0
-  amd64: ghcr.io/hassio-addons/debian-base:9.1.0
+  aarch64: ghcr.io/hassio-addons/debian-base:9.3.0
+  amd64: ghcr.io/hassio-addons/debian-base:9.3.0

--- a/vscode/requirements.txt
+++ b/vscode/requirements.txt
@@ -1,2 +1,2 @@
-esphome==2025.11.0
-yamllint==1.37.1
+esphome==2026.7.2
+yamllint==1.38.0

--- a/vscode/vscode.extensions
+++ b/vscode/vscode.extensions
@@ -1,8 +1,8 @@
-emilast.LogFileHighlighter#3.4.5
-esbenp.prettier-vscode#11.0.0
-ESPHome.esphome-vscode#2025.4.2
+emilast.LogFileHighlighter#3.5.1
+esbenp.prettier-vscode#12.4.0
+ESPHome.esphome-vscode#2026.4.0
 keesschollaart.vscode-home-assistant#2.2.0
 lukas-tr.materialdesignicons-intellisense#4.1.0
 oderwat.indent-rainbow#8.3.1
-redhat.vscode-yaml#1.11.10112022
-usernamehw.errorlens#3.26.0
+redhat.vscode-yaml#1.25.2026072408
+usernamehw.errorlens#3.28.0


### PR DESCRIPTION
## Summary
- update the bundled code-server version to v4.130.0
- move the build to the newer Debian base image tag 9.3.0
- refresh the pinned apt packages and the related Home Assistant CLI version
- update the Python and VS Code extension dependency versions used by the add-on

## Notes
- This PR keeps the dependency refresh focused on the runtime/build stack for the add-on.
- The branch name follows the requested convention and the release tag created for this change is v6.1.0.

## Testing
- Verified the repository changes locally on the requested branch.
- Built the add-on image with Docker from the updated Dockerfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the development environment’s base system image and bundled software packages.
  * Refreshed the YAML and Error Lens editor extensions.
  * Updated automated dependency tracking to identify the current code-server package correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->