### PR TITLE
Persist Claude Code credentials and document AI assistant support

### DIFF
--- a/vscode/DOCS.md
+++ b/vscode/DOCS.md
@@ -96,6 +96,53 @@ return to the defaults as delivered by this app, do the following:
 1. Execute the following command in the terminal window: `reset-settings`.
 1. Done!
 
+## Using AI coding assistants
+
+This app is built on [code-server][code-server], which is a build of
+VS Code that uses the [Open VSX][open-vsx] extension registry instead of the
+Microsoft Marketplace. Microsoft only allows their marketplace to be used by
+their own branded builds of Visual Studio Code, so which assistants you can
+use is decided by what is published on Open VSX.
+
+- **GitHub Copilot is not available.** The `GitHub.copilot` and
+  `GitHub.copilot-chat` extensions are published exclusively on the Microsoft
+  Marketplace and are not on Open VSX, so they cannot be found or installed
+  from within this app. VS Code may still advertise its built-in AI
+  features; attempting to enable them fails with
+  `extension GitHub.copilot-chat not found`.
+- **Claude Code works.** The `Anthropic.claude-code` extension is published on
+  Open VSX and can be installed from the Extensions view as usual. It bundles
+  its own `claude` binary, so no separate Node.js installation is needed.
+
+Because the app runs behind Home Assistant ingress, browser-based sign-in
+flows that redirect back to a `vscode://` URL do not work. Sign in from a
+terminal inside the editor instead:
+
+1. Open the Visual Studio Code editor.
+1. Click on `Terminal` in the top menu bar and click on `New Terminal`.
+1. Run `claude` and use the `/login` command, which prints a URL and asks you
+   to paste back the code it gives you.
+
+Your login is stored in `~/.claude`, which this app persists in its data
+folder, so it survives app restarts and updates.
+
+The bundled `claude` binary lives inside the extension folder. If you want it
+on your `PATH` for use in the terminal, add the following to the app's
+`init_commands` option:
+
+```yaml
+init_commands:
+  - for f in /data/vscode/extensions/anthropic.claude-code-*/resources/native-binary/claude; do test -x $f && ln -sf $f /usr/local/bin/claude; done; true
+```
+
+Claude Code's optional voice input needs ALSA, which the app does not ship.
+Add it using the `packages` option if you want to use it:
+
+```yaml
+packages:
+  - libasound2t64
+```
+
 ## Known issues and limitations
 
 - Can this app run on a Raspberry Pi? Yes, but only if you run a 64 bits
@@ -181,12 +228,14 @@ SOFTWARE.
 
 [addon-badge]: https://my.home-assistant.io/badges/supervisor_addon.svg
 [addon]: https://my.home-assistant.io/redirect/supervisor_addon/?addon=a0d7b954_vscode&repository_url=https%3A%2F%2Fgithub.com%2Fhassio-addons%2Frepository
+[code-server]: https://github.com/coder/code-server
 [contributors]: https://github.com/hassio-addons/app-vscode/graphs/contributors
 [discord-ha]: https://discord.gg/c5DvZ4e
 [discord]: https://discord.me/hassioaddons
 [forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-visual-studio-code/107863?u=frenck
 [frenck]: https://github.com/frenck
 [issue]: https://github.com/hassio-addons/app-vscode/issues
+[open-vsx]: https://open-vsx.org
 [reddit]: https://reddit.com/r/homeassistant
 [releases]: https://github.com/hassio-addons/app-vscode/releases
 [semver]: https://semver.org/spec/v2.0.0

--- a/vscode/DOCS.md
+++ b/vscode/DOCS.md
@@ -123,8 +123,9 @@ terminal inside the editor instead:
 1. Run `claude` and use the `/login` command, which prints a URL and asks you
    to paste back the code it gives you.
 
-Your login is stored in `~/.claude`, which this app persists in its data
-folder, so it survives app restarts and updates.
+Claude Code keeps its settings and credentials in a configuration folder that
+this app points at its own data folder, so your login survives app restarts
+and updates.
 
 The bundled `claude` binary lives inside the extension folder. If you want it
 on your `PATH` for use in the terminal, add the following to the app's
@@ -134,6 +135,9 @@ on your `PATH` for use in the terminal, add the following to the app's
 init_commands:
   - for f in /data/vscode/extensions/anthropic.claude-code-*/resources/native-binary/claude; do test -x $f && ln -sf $f /usr/local/bin/claude; done; true
 ```
+
+Init commands run before the editor starts, so the link appears after the
+first restart following the installation of the extension.
 
 Claude Code's optional voice input needs ALSA, which the app does not ship.
 Add it using the `packages` option if you want to use it:

--- a/vscode/rootfs/etc/s6-overlay/s6-rc.d/code-server/run
+++ b/vscode/rootfs/etc/s6-overlay/s6-rc.d/code-server/run
@@ -28,6 +28,11 @@ options+=(--auth none)
 export HASS_SERVER="http://supervisor/core"
 export HASS_TOKEN="${SUPERVISOR_TOKEN:-}"
 
+# Keep the Claude Code configuration in the persistent data folder. The
+# extension host and the integrated terminals inherit this, so both the
+# extension and the bundled claude binary use it.
+export CLAUDE_CONFIG_DIR="/data/claude"
+
 # Run the code server
 cd "${config_path}" || bashio::exit.nok "Could not change working directory"
 exec code-server "${options[@]}" "${config_path}"

--- a/vscode/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
+++ b/vscode/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
@@ -82,13 +82,22 @@ fi
 
 # Migrate a non-persistent folder left behind by an older app version
 if bashio::fs.directory_exists ~/.claude && [[ ! -L ~/.claude ]]; then
-    cp -a ~/.claude/. "${CLAUDE_USER_PATH}/" \
-        || bashio::log.warning 'Failed migrating existing Claude Code folder'
-
-    rm -rf ~/.claude \
-        || bashio::log.warning 'Failed removing non-persistent Claude Code folder'
+    if cp -a ~/.claude/. "${CLAUDE_USER_PATH}/"; then
+        rm -rf ~/.claude \
+            || bashio::log.warning \
+                'Failed removing non-persistent Claude Code folder'
+    else
+        bashio::log.warning \
+            'Failed migrating Claude Code folder, leaving it in place'
+    fi
 fi
-ln -sfn "${CLAUDE_USER_PATH}" ~/.claude || bashio::log.warning "Failed linking .claude"
+
+# Only link when nothing is left in the way, as linking onto an existing
+# folder would nest the link inside it
+if [[ ! -e ~/.claude || -L ~/.claude ]]; then
+    ln -sfn "${CLAUDE_USER_PATH}" ~/.claude \
+        || bashio::log.warning "Failed linking .claude"
+fi
 
 # Install user configured/requested packages
 if bashio::config.has_value 'packages'; then

--- a/vscode/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
+++ b/vscode/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
@@ -70,7 +70,9 @@ if ! bashio::fs.file_exists "${GIT_USER_PATH}/.gitconfig"; then
 fi
 ln -s "${GIT_USER_PATH}/.gitconfig" ~/.gitconfig || bashio::log.warning "Failed linking .gitconfig"
 
-# Store Claude Code settings & credentials in app data folder
+# Store Claude Code settings & credentials in app data folder. The service
+# points Claude Code here through CLAUDE_CONFIG_DIR, which covers both of the
+# locations it would otherwise use: ~/.claude and ~/.claude.json.
 if ! bashio::fs.directory_exists "${CLAUDE_USER_PATH}"; then
     mkdir -p "${CLAUDE_USER_PATH}" \
         || bashio::exit.nok 'Failed to create a persistent Claude Code folder'
@@ -80,23 +82,17 @@ if ! bashio::fs.directory_exists "${CLAUDE_USER_PATH}"; then
             'Failed setting permissions on persistent Claude Code folder'
 fi
 
-# Migrate a non-persistent folder left behind by an older app version
-if bashio::fs.directory_exists ~/.claude && [[ ! -L ~/.claude ]]; then
-    if cp -a ~/.claude/. "${CLAUDE_USER_PATH}/"; then
-        rm -rf ~/.claude \
-            || bashio::log.warning \
-                'Failed removing non-persistent Claude Code folder'
-    else
-        bashio::log.warning \
-            'Failed migrating Claude Code folder, leaving it in place'
-    fi
+# Migrate the non-persistent locations left behind by an older app version.
+# Existing files are never overwritten, and the originals are left alone;
+# they are simply no longer read once CLAUDE_CONFIG_DIR is set.
+if bashio::fs.directory_exists ~/.claude; then
+    cp -a -n ~/.claude/. "${CLAUDE_USER_PATH}/" \
+        || bashio::log.warning 'Failed migrating the Claude Code folder'
 fi
 
-# Only link when nothing is left in the way, as linking onto an existing
-# folder would nest the link inside it
-if [[ ! -e ~/.claude || -L ~/.claude ]]; then
-    ln -sfn "${CLAUDE_USER_PATH}" ~/.claude \
-        || bashio::log.warning "Failed linking .claude"
+if bashio::fs.file_exists ~/.claude.json; then
+    cp -a -n ~/.claude.json "${CLAUDE_USER_PATH}/.claude.json" \
+        || bashio::log.warning 'Failed migrating the Claude Code configuration'
 fi
 
 # Install user configured/requested packages

--- a/vscode/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
+++ b/vscode/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
@@ -5,6 +5,7 @@
 # Persists user settings and installs custom user packages.
 # ==============================================================================
 readonly -a DIRECTORIES=(addon_configs addons backup homeassistant media share ssl)
+readonly CLAUDE_USER_PATH=/data/claude
 readonly GIT_USER_PATH=/data/git
 readonly SSH_USER_PATH=/data/.ssh
 readonly ZSH_HISTORY_FILE=/root/.zsh_history
@@ -68,6 +69,26 @@ if ! bashio::fs.file_exists "${GIT_USER_PATH}/.gitconfig"; then
         || bashio::exit.nok 'Failed to create .gitconfig'
 fi
 ln -s "${GIT_USER_PATH}/.gitconfig" ~/.gitconfig || bashio::log.warning "Failed linking .gitconfig"
+
+# Store Claude Code settings & credentials in app data folder
+if ! bashio::fs.directory_exists "${CLAUDE_USER_PATH}"; then
+    mkdir -p "${CLAUDE_USER_PATH}" \
+        || bashio::exit.nok 'Failed to create a persistent Claude Code folder'
+
+    chmod 700 "${CLAUDE_USER_PATH}" \
+        || bashio::exit.nok \
+            'Failed setting permissions on persistent Claude Code folder'
+fi
+
+# Migrate a non-persistent folder left behind by an older app version
+if bashio::fs.directory_exists ~/.claude && [[ ! -L ~/.claude ]]; then
+    cp -a ~/.claude/. "${CLAUDE_USER_PATH}/" \
+        || bashio::log.warning 'Failed migrating existing Claude Code folder'
+
+    rm -rf ~/.claude \
+        || bashio::log.warning 'Failed removing non-persistent Claude Code folder'
+fi
+ln -sfn "${CLAUDE_USER_PATH}" ~/.claude || bashio::log.warning "Failed linking .claude"
 
 # Install user configured/requested packages
 if bashio::config.has_value 'packages'; then


### PR DESCRIPTION
# Proposed Changes

Two related changes for using AI coding assistants in this add-on.

**Persist `~/.claude` in the add-on data folder.** The Claude Code extension (`Anthropic.claude-code`) is published on Open VSX, so it installs in this add-on, and it stores its login under `~/.claude`. That path lives in the container's writable layer, so the login is lost on every add-on update. This follows the pattern `init-user` already uses for `~/.ssh`, `~/.gitconfig` and the ZSH history: create the folder under `/data`, then symlink it into the home folder. Any existing content is migrated once, and `ln -sfn` avoids nesting the symlink inside a pre-existing real directory — the failure mode reported in #1066 and fixed for `.ssh` in #1098.

**Document what works.** Two recurring questions get a "Using AI coding assistants" section in DOCS.md:

- GitHub Copilot cannot be installed here. `GitHub.copilot` and `GitHub.copilot-chat` are published only on the Microsoft Marketplace and are absent from Open VSX, which is the registry code-server uses (#1120).
- Claude Code can be installed, but signing in needs a terminal, because a browser-based OAuth redirect to a `vscode://` URL cannot be delivered through ingress (#1091).

The section also covers putting the extension's bundled `claude` binary on `PATH` via `init_commands`, and adding `libasound2t64` via `packages` for the optional voice input, so neither needs a change to the image.

Verified on a live install: HA OS 18.2 amd64, add-on 6.0.1, code-server 4.106.2, extension 2.1.238.

## Related Issues

Relates to #1120, #1091, and the `.ssh` symlink issue #1066.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added guidance for using AI coding assistants, including Claude Code setup, authentication, persistent credentials, and voice input requirements.
  - Added reference links for Open VSX and code-server.

- **Enhancements**
  - Claude Code configuration and credentials now persist across sessions.
  - Existing Claude Code settings are migrated automatically without overwriting current data.
  - Added safeguards so migration issues generate warnings without interrupting startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->