### PR TITLE
Track Debian apt pins with the Renovate deb datasource

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,8 +25,8 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
       ],
       "versioningTemplate": "deb",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "debian_13/{{{replace 'openssh-client' 'openssh' package}}}"
+      "datasourceTemplate": "deb",
+      "depNameTemplate": "{{{package}}}"
     },
     {
       "customType": "regex",
@@ -109,7 +109,12 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["deb"],
+      "registryUrls": [
+        "https://deb.debian.org/debian?suite=trixie&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian?suite=trixie-updates&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian-security?suite=trixie-security&components=main&binaryArch=amd64"
+      ],
       "automerge": true
     },
     {


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Ports hassio-addons/app-vaultwarden#447 to this app.

Repology indexes **source** package names, so it has to be told that `openssh-client` lives in the `openssh` source package, which is why this repository carried a hand written mapping in `depNameTemplate`. Every future pin whose binary and source names differ needs the same treatment, and getting it wrong fails silently: the package simply stops being updated.

Renovate's native [`deb` datasource](https://docs.renovatebot.com/modules/datasource/deb/) reads the Debian package indices directly and indexes **binary** names, so `depNameTemplate` becomes plain `{{{package}}}` and the mapping disappears.

The registry URLs are a one to one mirror of the apt sources in `ghcr.io/hassio-addons/debian-base:9.4.0`:

| Source | Suite | Component |
| --- | --- | --- |
| `deb.debian.org/debian` | `trixie` | `main` |
| `deb.debian.org/debian` | `trixie-updates` | `main` |
| `deb.debian.org/debian-security` | `trixie-security` | `main` |

The `deb` datasource uses a `merge` registry strategy, so releases from all three are aggregated rather than first one wins.

### Known limitation

Same as in the Vaultwarden PR: the datasource hardcodes `Packages.gz`, and only `trixie` serves it. Confirmed against the archive:

| Index | Status |
| --- | --- |
| `debian/dists/trixie/main/binary-amd64/Packages.gz` | 200 |
| `debian/dists/trixie-updates/main/binary-amd64/Packages.gz` | 404 |
| `debian-security/dists/trixie-security/main/binary-amd64/Packages.gz` | 404 |
| `debian/dists/trixie-updates/main/binary-amd64/Packages.xz` | 200 |
| `debian-security/dists/trixie-security/main/binary-amd64/Packages.xz` | 200 |

So `trixie-updates` and `trixie-security` are inert for now. This fails gracefully, lookups are caught and skipped per component, and the two suites start working on their own once renovatebot/renovate#44330 lands. They are kept in the configuration so it stays a truthful description of what the image actually pulls from.

### Impact on this app

Better than in Vaultwarden, as it happens. All 22 pins in `vscode/Dockerfile` are present in `trixie` `main`, so nothing stops being tracked:

```
tracked by trixie/main: 22/22   not found: 0
```

Four of them are currently pinned to `trixie-security` versions that are ahead of `main`:

| Package | Pinned | In `trixie` `main` |
| --- | --- | --- |
| `openssl` | `3.5.7-1~deb13u2` | `3.5.6-1~deb13u2` |
| `unzip` | `6.0-29+deb13u1` | `6.0-29` |
| `uuid-runtime` | `2.41.5-0+deb13u1` | `2.41-5` |
| `zip` | `3.0-15+deb13u1` | `3.0-15` |

Those four stay where they are until a Debian point release folds the security update into `main`, or until the upstream fix lands and the security suite starts resolving. Renovate does not roll back by default, so no downgrade is proposed in the meantime, and the pins keep building exactly as they do today.

### Verification

- `renovate-config-validator` from Renovate 44: `Config validated successfully`.
- The manager regex was run against `vscode/Dockerfile` and still extracts all 22 pins with the correct names and versions.
- The suite each pin resolves from was read out of `apt-cache policy` inside `debian-base:9.4.0`, and the `trixie` `main` versions above come from the published `Packages.gz`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Ports hassio-addons/app-vaultwarden#447.

Upstream: renovatebot/renovate#44330, with renovatebot/renovate#35865 open against it.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Debian package update tracking to use the Debian package source.
  * Limited package lookups to the supported Debian Trixie repositories and amd64 architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->